### PR TITLE
I2s2

### DIFF
--- a/hdl/edge_detector.sv
+++ b/hdl/edge_detector.sv
@@ -1,0 +1,28 @@
+`timescale 1ns/1ps
+
+module edge_detector(clk, rst, in, positive_edge, negative_edge);
+
+input wire clk, rst, in;
+output logic positive_edge, negative_edge;
+
+// SOLUTION START
+logic last_in; // Flip flop to store last input value.
+
+always @(posedge clk) begin
+  if(rst) begin
+    last_in <= 0;
+  end else begin
+    last_in <= in;
+  end
+end
+
+// This is a Mealy machine since the output states are combinational on the input.
+// You'll see a waveform (that will still work) that is only high for half a clock cycle
+// in the testbench, that is okay!
+always_comb begin : mealy_output_logic
+  positive_edge = in & ~last_in;
+  negative_edge = ~in & last_in;
+end
+// SOLUTION END
+
+endmodule

--- a/hdl/i2s2.sv
+++ b/hdl/i2s2.sv
@@ -1,0 +1,149 @@
+// Driver I2S2 Protocol 24-bit
+`timescale 1ns/1ps
+
+module i2s2(rch1, rch2, wch1, wch2, datain, dataout, valid, lrclk, sclk, mclk, rst);
+
+/*************************************************************************************************
+* This module implements a multipurpose I2S (Inter-IC Sound) driver capable of converting analog 
+* signals to digital format and vice versa, specifically designed for a 24-bit bit depth and a 
+* 44.1kHz sampling rate. 44.1kHz is the standard CD sampling rate. CDs usually only use 16-bit
+* audio, however, our module supports higher bit depths. Other sampling rates are supported but our
+* FPGA might not be able to handle the required clock frequency. The module interfaces with audio data 
+* through its inputs and outputs, utilizing a master clock (mclk), a left-right clock (lrclk), and 
+* a serial clock (sclk) to manage the timing and synchronization of audio data transmission. We built
+* this module to work with the Digilent Pmod I2S2.
+*
+* Inputs:
+*   - datain: Serial input data stream.
+*   - mclk: Main clock input, serves as the master clock for the module.
+*   - lrclk: Left-Right clock input, determines the current channel (left or right) for audio data.
+*   - sclk: Serial clock input, governs the serial data transmission timing.
+*   - rst: Reset input, asynchronously resets the module to a known state.
+*   - wch1, wch2: Input channels for writing audio data, 24 bits each.
+*
+* Outputs:
+*   - rch1, rch2: Output channels for reading audio data, 24 bits each.
+*   - dataout: Serial output data stream.
+*   - valid: Output flag indicating valid data transfer.
+*
+* The module is set up to move between FSM states on clock edges, this is done via an
+* edge detector that finds positive and negative edges. This ensures proper transitions.
+*************************************************************************************************/
+
+
+parameter N = 24; //unused
+
+input wire datain, lrclk, sclk, mclk, rst;
+input wire [N-1:0] wch1, wch2;
+output logic [N-1:0] rch1, rch2;
+output logic dataout, valid;
+
+wire possclk, negsclk, poslrclk, neglrclk;
+logic lredge;
+
+logic [N-1:0] wlreg, wrreg;
+logic [4:0] counter;
+logic [2:0] delay;
+
+  enum logic [2:0]{ //state variables for FSM (COM is legacy, unused)
+  S_ERROR=0,
+  S_IDLE=1,
+  S_COM=2,
+  S_REC=3
+} state;
+
+  enum logic { //state variables for SCLK sync
+  S_LEFT=0,
+  S_RIGHT=1
+} lr_state;
+
+edge_detector S(.clk(mclk), .rst(rst), .in(sclk), .positive_edge(possclk), .negative_edge(negsclk)); //SCLK edge detector relative to mclk
+edge_detector LR(.clk(sclk), .rst(rst), .in(lrclk), .positive_edge(poslrclk), .negative_edge(neglrclk)); //LRCLK edge detector relative to sclk
+always_comb lredge=poslrclk|neglrclk; //detect both edges of LRCLK
+
+always_ff @(posedge mclk) begin //Left-Right transition FSM
+    if(rst) begin //start on left channel
+        lr_state<=S_LEFT;
+        delay<=0;
+    end
+    if(&delay) begin //transition on lredge to opposite state
+        if(lredge&(lr_state==S_RIGHT)) begin
+            lr_state<=S_LEFT;
+            delay<=0;
+        end
+        if(lredge&(lr_state==S_LEFT)) begin
+            lr_state<=S_RIGHT;
+            delay<=0;
+        end
+    end
+    if(delay<7) begin //add delay to prevent switching multiple times per SCLK
+        delay<=delay+1;
+    end
+end
+
+// FSM driver
+always_ff @(posedge mclk) begin
+    if(rst) begin //reset system
+        state<=S_IDLE;
+        rch1<='0;
+        rch2<='0;
+        dataout<=1'b0;
+        valid<=1'b1;
+        counter<=0;
+        wlreg<='0;
+        wrreg<='0;
+    end
+    case(state)
+        S_IDLE : begin
+            dataout<=0;
+            if(lredge) begin //if LRCLK changes, start I2S cycle
+                state<=S_REC;
+                counter<=0;
+                if(lr_state==S_LEFT) begin
+                    wlreg<=wch1;
+                    wrreg<=wch2;
+                end
+            end
+        end
+        S_COM : begin //this state is unused for timing reasons
+            if(negsclk|(lr_state==S_LEFT)) begin
+                state<=S_REC;
+                counter<=0;
+                if(lr_state==S_LEFT) begin
+                    wlreg<=wch1;
+                    wrreg<=wch2;
+                end
+            end
+        end
+        S_REC : begin
+            valid<=0;
+            if(negsclk) begin //on negative edges, write data
+                if(lr_state==S_LEFT) begin
+                    dataout<=wlreg[23];
+                    wlreg[23:1]<=wlreg[22:0];
+                end
+                if(lr_state==S_RIGHT) begin
+                    dataout<=wrreg[23];
+                    wrreg[23:1]<=wrreg[22:0];
+                end
+                counter<=counter+1;
+            end
+            if(possclk) begin //on positive edges, read data
+                if(lr_state==S_LEFT) begin
+                    rch1[0]<=datain;
+                    rch1[23:1]<=rch1[22:0];
+                end
+                if(lr_state==S_RIGHT) begin
+                    rch2[0]<=datain;
+                    rch2[23:1]<=rch2[22:0];
+                end
+                if(counter>=5'd24) begin //return to IDLE after 24 datapoints
+                    state<=S_IDLE;
+                    valid<=1;
+                end
+            end
+        end
+    endcase
+end
+
+endmodule

--- a/hdl/main.sv
+++ b/hdl/main.sv
@@ -21,14 +21,18 @@ eth_rxd, //4-bit
 eth_rxerr,
 eth_tx_clk,
 eth_tx_en,
-eth_txd //4-bit
+eth_txd, //4-bit
+mclk, // I2S2
+lrclk,
+sclk,
+sdin
 );
 
 // General
-input wire mainclk;     // 100 MHz
+input wire mainclk;     // 100 MHz | 90.24 MHz
 logic [16:0] clk_divider;
-logic dataclk;           // 25 MHz
-logic uartclk;           // 12.5 MHz
+logic dataclk;           // 25 MHz | 22.56 MHz
+logic uartclk;           // 12.5 MHz | 11.28 MHz
 input wire [3:0] btn;   // Buttons
 input wire [3:0] sw;    // Switches
 logic rst;
@@ -40,6 +44,7 @@ wire tx_ready;
 logic tx_valid;
 logic [7:0] tx_data;
 logic [31:0] read_buffer;
+logic [31:0] pb_read_buffer;
 
 always_comb rst = |btn[3:1];
 
@@ -49,13 +54,94 @@ always_ff @(posedge mainclk) begin : Clock_Divider
     clk_divider <= clk_divider + 1;
 end
 
+//##########################        I2S2        ################################
+
+output logic mclk;
+output logic lrclk;
+output logic sclk;
+output logic sdin;
+
+logic [23:0] wch1, wch2;
+parameter sclk_divider = 1; 
+logic [sclk_divider:0] sclk_counter; //4x less
+parameter lrclk_divider = 7;
+logic [lrclk_divider:0] lrclk_counter; //256x less
+parameter mclk_divider = 2;
+logic [mclk_divider:0] mclk_counter; //11.28 MHz
+
+//Clock divider
+always_comb begin
+  sclk = sclk_counter[sclk_divider];
+  mclk = mclk_counter[mclk_divider];
+  lrclk = lrclk_counter[lrclk_divider];
+end
+
+//Clock counters
+always_ff @(posedge mainclk) begin : main_clock
+    if (rst) begin
+      mclk_counter <= 0;
+    end else begin
+        if(&mclk_counter) begin
+        mclk_counter <= 0;
+      end
+      else begin
+        mclk_counter <= mclk_counter + 1;
+      end
+    end
+end 
+always_ff @(posedge mclk) begin : clocks_and_dividers 
+  if (rst) begin
+      sclk_counter <= 0;
+      lrclk_counter <= 0;
+  end
+  else begin
+      if(&sclk_counter) begin
+        sclk_counter <= 0;
+      end
+      else begin
+        sclk_counter <= sclk_counter + 1;
+      end
+      
+      if(&lrclk_counter) begin
+        lrclk_counter <= 0;
+      end
+      else begin
+        lrclk_counter <= lrclk_counter + 1;
+      end    
+  end
+end
+
+always_comb begin
+    wch1={8'b0,pb_read_buffer[15:0]};
+    wch2={8'b0,pb_read_buffer[31:16]};
+end
+
+always_ff @(posedge lrclk) begin : I2S2_Transmit
+    if(rst|pb_start) begin
+        pb_addr<=0;
+        pbbitcounter<=0;
+        pb_read_buffer[31:0]<=rd_data; //should fix 0 print error
+    end else begin
+        if(eth_state==PLAY_BACK) begin
+            if(pbbitcounter) begin
+                pb_addr<=pb_addr+1;
+                pb_read_buffer<=rd_data;
+            end
+        end
+    end
+end
+
+i2s2 AUDIO(.rch1(), .rch2(), .wch1(wch1), .wch2(wch2), .datain(), .dataout(sdin),
+            .valid(), .lrclk(lrclk), .sclk(sclk), .mclk(mclk), .rst(rst));
+
 //#######################        FS MACHINE        #############################
 
 enum logic [2:0] {
     E_ERR = 0,
     E_IDLE = 1,
     E_REC = 2,
-    U_TX = 3
+    U_TX = 3,
+    PLAY_BACK = 4
 } eth_state; 
 
 // enum logic [2:0] {
@@ -67,6 +153,8 @@ enum logic [2:0] {
 logic change_state;
 logic eth_start;
 logic uart_start;
+logic pb_start;
+
 logic one_shot;
 
 always_ff @(posedge mainclk) begin : Finite_State_Machine
@@ -75,21 +163,30 @@ always_ff @(posedge mainclk) begin : Finite_State_Machine
         one_shot<=1;
         eth_start<=1;
         uart_start<=1;
+        pb_start<=1;
         // uart_state<=U_IDLE;
     end
     if(eth_state==E_IDLE & change_state) begin
         eth_state<=E_REC;
         eth_start<=0;
         uart_start<=1;
+        pb_start<=1;
         one_shot<=0;
     end else if(eth_state==E_REC & change_state) begin
         eth_state<=U_TX;
         eth_start<=1;
         uart_start<=0; 
+        pb_start<=1;
     end else if(eth_state==U_TX & change_state) begin
+        eth_state<=PLAY_BACK;
+        eth_start<=1;
+        uart_start<=1;
+        pb_start<=0;
+    end else if(eth_state==PLAY_BACK & change_state) begin
         eth_state<=E_IDLE;
         eth_start<=1;
         uart_start<=1;
+        pb_start<=1;
     end
     one_shot<=btn[0];
 end
@@ -101,6 +198,8 @@ always_comb begin : State_Change
         change_state=~eth_rx_dv & tx_ready;
     end else if(eth_state==U_TX) begin
         change_state=(uart_addr>=9'd375); // TODO: add correct bound (375?)
+    end else if(eth_state==PLAY_BACK) begin
+        change_state=(pb_addr>=9'd375);
     end else begin
         change_state=0;
     end
@@ -190,25 +289,29 @@ end
 logic [8:0] addr;
 logic [8:0] eth_addr;
 logic [8:0] uart_addr;
+logic [8:0] pb_addr;
 logic wr_ena;
 logic [31:0] wr_data;
 wire [31:0] rd_data;
 logic [2:0] ethbitcounter;
 logic [4:0] uartbitcounter;
+logic pbbitcounter;
 
 always_comb begin
     if(eth_state==E_REC) begin
         addr = eth_addr;
     end else if(eth_state==U_TX) begin
         addr = uart_addr;
+    end  else if(eth_state==PLAY_BACK) begin
+        addr = pb_addr;
     end else begin
         addr = 0;
     end
 end
 
 block_ram #(.INIT("custom.memh")) RAM(
-  .clk(mainclk), .rd_addr(uart_addr), .rd_data(rd_data),
-  .wr_addr(eth_addr), .wr_ena(wr_ena), .wr_data(wr_data)
+  .clk(mainclk), .rd_addr(addr), .rd_data(rd_data),
+  .wr_addr(addr), .wr_ena(wr_ena), .wr_data(wr_data)
 );
 
 //#########################        OUTPUT        ###############################

--- a/main.xdc
+++ b/main.xdc
@@ -5,7 +5,9 @@
 
 ## Clock signal
 set_property -dict { PACKAGE_PIN E3    IOSTANDARD LVCMOS33 } [get_ports { mainclk }]; #IO_L12P_T1_MRCC_35 Sch=gclk[100]
-create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports { mainclk }];  #100 MHz
+# create_clock -add -name sys_clk_pin -period 11.08 -waveform {0 5.54} [get_ports { mainclk }];  #100 MHz
+create_clock -add -name sys_clk_pin -period 10 -waveform {0 5} [get_ports { mainclk }];  #100 MHz
+
 
 ## Switches
 set_property -dict { PACKAGE_PIN A8    IOSTANDARD LVCMOS33 } [get_ports { sw[0] }]; #IO_L12N_T1_MRCC_16 Sch=sw[0]
@@ -70,14 +72,14 @@ set_property -dict { PACKAGE_PIN B8    IOSTANDARD LVCMOS33 } [get_ports { btn[3]
 #set_property -dict { PACKAGE_PIN U13   IOSTANDARD LVCMOS33 } [get_ports { jc[7] }]; #IO_L23N_T3_A02_D18_14 Sch=jc_n[4]
 
 ## Pmod Header JD
-#set_property -dict { PACKAGE_PIN D4    IOSTANDARD LVCMOS33 } [get_ports { jd[0] }]; #IO_L11N_T1_SRCC_35 Sch=jd[1]
-#set_property -dict { PACKAGE_PIN D3    IOSTANDARD LVCMOS33 } [get_ports { jd[1] }]; #IO_L12N_T1_MRCC_35 Sch=jd[2]
-#set_property -dict { PACKAGE_PIN F4    IOSTANDARD LVCMOS33 } [get_ports { jd[2] }]; #IO_L13P_T2_MRCC_35 Sch=jd[3]
-#set_property -dict { PACKAGE_PIN F3    IOSTANDARD LVCMOS33 } [get_ports { jd[3] }]; #IO_L13N_T2_MRCC_35 Sch=jd[4]
-#set_property -dict { PACKAGE_PIN E2    IOSTANDARD LVCMOS33 } [get_ports { jd[4] }]; #IO_L14P_T2_SRCC_35 Sch=jd[7]
-#set_property -dict { PACKAGE_PIN D2    IOSTANDARD LVCMOS33 } [get_ports { jd[5] }]; #IO_L14N_T2_SRCC_35 Sch=jd[8]
-#set_property -dict { PACKAGE_PIN H2    IOSTANDARD LVCMOS33 } [get_ports { jd[6] }]; #IO_L15P_T2_DQS_35 Sch=jd[9]
-#set_property -dict { PACKAGE_PIN G2    IOSTANDARD LVCMOS33 } [get_ports { jd[7] }]; #IO_L15N_T2_DQS_35 Sch=jd[10]
+set_property -dict { PACKAGE_PIN D4    IOSTANDARD LVCMOS33 } [get_ports { mclk }]; #IO_L11N_T1_SRCC_35 Sch=jd[1]
+set_property -dict { PACKAGE_PIN D3    IOSTANDARD LVCMOS33 } [get_ports { lrclk }]; #IO_L12N_T1_MRCC_35 Sch=jd[2]
+set_property -dict { PACKAGE_PIN F4    IOSTANDARD LVCMOS33 } [get_ports { sclk }]; #IO_L13P_T2_MRCC_35 Sch=jd[3]
+set_property -dict { PACKAGE_PIN F3    IOSTANDARD LVCMOS33 } [get_ports { sdin }]; #IO_L13N_T2_MRCC_35 Sch=jd[4]
+# set_property -dict { PACKAGE_PIN E2    IOSTANDARD LVCMOS33 } [get_ports { jd[4] }]; #IO_L14P_T2_SRCC_35 Sch=jd[7]
+# set_property -dict { PACKAGE_PIN D2    IOSTANDARD LVCMOS33 } [get_ports { jd[5] }]; #IO_L14N_T2_SRCC_35 Sch=jd[8]
+# set_property -dict { PACKAGE_PIN H2    IOSTANDARD LVCMOS33 } [get_ports { jd[6] }]; #IO_L15P_T2_DQS_35 Sch=jd[9]
+# set_property -dict { PACKAGE_PIN G2    IOSTANDARD LVCMOS33 } [get_ports { jd[7] }]; #IO_L15N_T2_DQS_35 Sch=jd[10]
 
 ## USB-UART Interface
 set_property -dict { PACKAGE_PIN D10   IOSTANDARD LVCMOS33 } [get_ports { uart_rxd_out }]; #IO_L19N_T3_VREF_16 Sch=uart_rxd_out


### PR DESCRIPTION
There's an I2S2 driver which reads from a RAM module. It is set to run only after the ethernet runs instead of in parallel. That can be changed by simply removing the state condition on the driver and tying resetting the RAM address at the end of each transmission and bounding the address to prevent overshoots.